### PR TITLE
1572. Matrix Diagonal Sum

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="3473ac9c-5f98-4397-b462-e088cccabc3d" name="Changes" comment="682. Baseball Game&#10;Easy&#10;2.5K&#10;1.8K&#10;Companies&#10;You are keeping the scores for a baseball game with strange rules. At the beginning of the game, you start with an empty record.&#10;&#10;You are given a list of strings operations, where operations[i] is the ith operation you must apply to the record and is one of the following:&#10;&#10;An integer x.&#10;Record a new score of x.&#10;'+'.&#10;Record a new score that is the sum of the previous two scores.&#10;'D'.&#10;Record a new score that is the double of the previous score.&#10;'C'.&#10;Invalidate the previous score, removing it from the record.&#10;Return the sum of all the scores on the record after applying all the operations.&#10;&#10;The test cases are generated such that the answer and all intermediate calculations fit in a 32-bit integer and that all operations are valid.&#10;&#10; &#10;&#10;Example 1:&#10;&#10;Input: ops = [&quot;5&quot;,&quot;2&quot;,&quot;C&quot;,&quot;D&quot;,&quot;+&quot;]&#10;Output: 30&#10;Explanation:&#10;&quot;5&quot; - Add 5 to the record, record is now [5].&#10;&quot;2&quot; - Add 2 to the record, record is now [5, 2].&#10;&quot;C&quot; - Invalidate and remove the previous score, record is now [5].&#10;&quot;D&quot; - Add 2 * 5 = 10 to the record, record is now [5, 10].&#10;&quot;+&quot; - Add 5 + 10 = 15 to the record, record is now [5, 10, 15].&#10;The total sum is 5 + 10 + 15 = 30.&#10;Example 2:&#10;&#10;Input: ops = [&quot;5&quot;,&quot;-2&quot;,&quot;4&quot;,&quot;C&quot;,&quot;D&quot;,&quot;9&quot;,&quot;+&quot;,&quot;+&quot;]&#10;Output: 27&#10;Explanation:&#10;&quot;5&quot; - Add 5 to the record, record is now [5].&#10;&quot;-2&quot; - Add -2 to the record, record is now [5, -2].&#10;&quot;4&quot; - Add 4 to the record, record is now [5, -2, 4].&#10;&quot;C&quot; - Invalidate and remove the previous score, record is now [5, -2].&#10;&quot;D&quot; - Add 2 * -2 = -4 to the record, record is now [5, -2, -4].&#10;&quot;9&quot; - Add 9 to the record, record is now [5, -2, -4, 9].&#10;&quot;+&quot; - Add -4 + 9 = 5 to the record, record is now [5, -2, -4, 9, 5].&#10;&quot;+&quot; - Add 9 + 5 = 14 to the record, record is now [5, -2, -4, 9, 5, 14].&#10;The total sum is 5 + -2 + -4 + 9 + 5 + 14 = 27.&#10;Example 3:&#10;&#10;Input: ops = [&quot;1&quot;,&quot;C&quot;]&#10;Output: 0&#10;Explanation:&#10;&quot;1&quot; - Add 1 to the record, record is now [1].&#10;&quot;C&quot; - Invalidate and remove the previous score, record is now [].&#10;Since the record is empty, the total sum is 0.&#10; &#10;&#10;Constraints:&#10;&#10;1 &lt;= operations.length &lt;= 1000&#10;operations[i] is &quot;C&quot;, &quot;D&quot;, &quot;+&quot;, or a string representing an integer in the range [-3 * 104, 3 * 104].&#10;For operation &quot;+&quot;, there will always be at least two previous scores on the record.&#10;For operations &quot;C&quot; and &quot;D&quot;, there will always be at least one previous score on the record.">
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/FindWinnerOnATicTacToeGame1275.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/MatrixDiagonalSum1572.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -23,7 +23,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="682._Baseball_Game" />
+        <entry key="$PROJECT_DIR$" value="1041._Robot_Bounded_In_Circle_" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -46,7 +46,7 @@
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "1275.__Find__Winner__on__a__Tic__Tac__Toe__Game__",
+    "git-widget-placeholder": "1572.__Matrix__Diagonal__Sum__",
     "ignore.virus.scanning.warn.message": "true",
     "last_opened_file_path": "C:/springApps/LeetCodeSolutions"
   }
@@ -57,7 +57,7 @@
       <recent name="C:\springApps\LeetCodeSolutions\src\main\java\org\example" />
     </key>
   </component>
-  <component name="RunManager" selected="Application.FindWinnerOnATicTacToeGame1275">
+  <component name="RunManager" selected="Application.MatrixDiagonalSum1572">
     <configuration name="BaseballGame682" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="org.example.BaseballGame682" />
       <module name="LeetCodeSolutions" />
@@ -97,8 +97,8 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="MaximumTwinSumOfALinkedList2130" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
-      <option name="MAIN_CLASS_NAME" value="org.example.MaximumTwinSumOfALinkedList2130" />
+    <configuration name="MatrixDiagonalSum1572" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
+      <option name="MAIN_CLASS_NAME" value="org.example.MatrixDiagonalSum1572" />
       <module name="LeetCodeSolutions" />
       <extension name="coverage">
         <pattern>
@@ -125,11 +125,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Application.MatrixDiagonalSum1572" />
         <item itemvalue="Application.FindWinnerOnATicTacToeGame1275" />
         <item itemvalue="Application.BaseballGame682" />
         <item itemvalue="Application.Pow_50" />
         <item itemvalue="Application.Main" />
-        <item itemvalue="Application.MaximumTwinSumOfALinkedList2130" />
       </list>
     </recent_temporary>
   </component>
@@ -583,6 +583,11 @@
           <url>file://$PROJECT_DIR$/src/main/java/org/example/FindWinnerOnATicTacToeGame1275.java</url>
           <line>18</line>
           <option name="timeStamp" value="124" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/org/example/MatrixDiagonalSum1572.java</url>
+          <line>9</line>
+          <option name="timeStamp" value="127" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-method">
           <url>file://$PROJECT_DIR$/src/main/java/org/example/ValidPalindrome125.java</url>

--- a/src/main/java/org/example/MatrixDiagonalSum1572.java
+++ b/src/main/java/org/example/MatrixDiagonalSum1572.java
@@ -1,0 +1,20 @@
+package org.example;
+
+public class MatrixDiagonalSum1572 {
+    public static void main(String[] args) {
+int[][] mat = {{1,1,1,1},{1,1,1,1},{1,1,1,1},{1,1,1,1}};
+        System.out.println(diagonalSum(mat));
+    }
+    public static int diagonalSum(int[][] mat) {
+        int sum = 0;
+        for (int i = 0; i < mat.length; i++) {
+            sum =sum+mat[i][i];
+            sum =sum+mat[i][mat.length-i-1];
+        }
+        if(mat.length%2!=0)
+        {
+            return sum-mat[mat.length/2][mat.length/2];
+        }
+      return sum;
+    }
+}


### PR DESCRIPTION
Easy
3.1K
41
Companies
Given a square matrix mat, return the sum of the matrix diagonals.

Only include the sum of all the elements on the primary diagonal and all the elements on the secondary diagonal that are not part of the primary diagonal.

Example 1:

Input: mat = [[1,2,3],
              [4,5,6],
              [7,8,9]]
Output: 25
Explanation: Diagonals sum: 1 + 5 + 9 + 3 + 7 = 25 Notice that element mat[1][1] = 5 is counted only once. Example 2:

Input: mat = [[1,1,1,1],
              [1,1,1,1],
              [1,1,1,1],
              [1,1,1,1]]
Output: 8
Example 3:

Input: mat = [[5]]
Output: 5

Constraints:

n == mat.length == mat[i].length
1 <= n <= 100
1 <= mat[i][j] <= 100
Accepted
281.5K
Submissions
340.2K
Acceptance Rate
82.7%